### PR TITLE
Move to Scala.js 0.6.0 and change JVM project name to allow for shared module dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,10 +38,9 @@ lazy val root = project.in(file("."))
       publish := {},
       publishLocal := {}
   )
-  .aggregate(core, corejvm, js, playjson, tests)
+  .aggregate(corejs, corejvm, js, playjson, tests)
 
-lazy val core = project
-  .enablePlugins(ScalaJSPlugin)
+lazy val core = crossProject.crossType(CrossType.Pure)
   .settings(commonSettings: _*)
   .settings(enableQuasiquotesIn210: _*)
   .settings(
@@ -50,15 +49,8 @@ lazy val core = project
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
   )
 
-lazy val corejvm = project
-  .settings(commonSettings: _*)
-  .settings(enableQuasiquotesIn210: _*)
-  .settings(
-    sourceDirectory := (sourceDirectory in core).value,
-    name := "Scala.js pickling core jvm",
-    libraryDependencies +=
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
-  )
+lazy val corejvm = core.jvm
+lazy val corejs = core.js
 
 lazy val js = project
   .enablePlugins(ScalaJSPlugin)
@@ -66,7 +58,7 @@ lazy val js = project
   .settings(
     name := "Scala.js pickling"
   )
-  .dependsOn(core)
+  .dependsOn(corejs)
 
 lazy val playjson = project
   .settings(commonSettings: _*)
@@ -86,7 +78,7 @@ lazy val tests = project
     publishLocal := {},
     name := "Scala.js pickling tests",
     libraryDependencies +=
-      "com.lihaoyi" %%% "utest" % "0.2.5-RC1" % "test",
+      "com.lihaoyi" %%% "utest" % "0.3.0" % "test",
     testFrameworks += new TestFramework("utest.runner.Framework")
   )
   .dependsOn(js)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-RC2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0")


### PR DESCRIPTION
Thanks for this library, it's pretty great.

This pull request builds and tests correctly with Scala.js 0.6.0.

I simplified the JVM project and additionally changed it to have the same name as the JS project. This is more convenient for using scala-js-pickling in a shared module. In my shared module, I have a `MessagesRegistry` class that adds messages to the `PicklerRegistry`, called at startup in play & scalajs. This involved some extra build settings until I made this change; after this change my shared module only needs a `"org.scalajs" %%% "scalajs-pickling-core" % "0.4-SNAPSHOT"` dependency to compile and run on both JS/JVM.
